### PR TITLE
Allow FEFMM to be more flexible with types

### DIFF
--- a/src/factoredeikonalfmm.jl
+++ b/src/factoredeikonalfmm.jl
@@ -137,3 +137,4 @@ function fefmm(κ2::Array{R, N},
     fefmm_loop!(τ1, 1, ordering, α, β, τ0, ∇τ0, tags, front, κ2, dx, cs, xn, I1, Iend, LI)
     (τ1.*τ0, ordering)
 end
+

--- a/src/factoredeikonalfmm.jl
+++ b/src/factoredeikonalfmm.jl
@@ -1,13 +1,13 @@
 function solve_node(τ1::Array{R, N}, 
-                    α::Array{R, 1},
-                    β::Array{R, 1},
+                    α::Vector{R},
+                    β::Vector{R},
                     τ0::Array{R, N},
                     ∇τ0::Array{T},
                     tags::Array{UInt8, N},
                     κ2::Array{R, N},
                     x::S,
-                    dx::Array{R, 1}, 
-                    cs::Array{S, 1}, 
+                    dx::Vector{<:AbstractFloat},
+                    cs::Vector{S},
                     I1::S, 
                     Iend::S) where {N, R <: AbstractFloat, T <: Array{R, N}, S <: CartesianIndex{N}}
     #loop over dimensions to set \alpha and \beta ...
@@ -58,18 +58,18 @@ end
 
 
 function fefmm_loop!(τ1::Array{R, N}, 
-                     ocount::Int,
-                     ordering::Array{Int, 1},
-                     α::Array{R,1},
-                     β::Array{R,1},
+                     ocount::Integer,
+                     ordering::Vector{<:Integer},
+                     α::Vector{R},
+                     β::Vector{R},
                      τ0::Array{R, N}, 
                      ∇τ0::Array{T},
                      tags::Array{UInt8, N}, 
                      front::BinaryMinHeap{Node{R, N}},
                      κ2::Array{R, N},
-                     dx::Array{R, 1}, 
-                     cs::Array{S, 1}, 
-                     xn::Array{S, 1},
+                     dx::Vector{<:AbstractFloat},
+                     cs::Vector{S},
+                     xn::Vector{S},
                      I1::S, 
                      Iend::S, 
                      LI::LinearIndices{N}) where {N, R <: AbstractFloat, T <: Array{R, N}, S <: CartesianIndex{N}}
@@ -111,7 +111,9 @@ Tags:
 3 = known
 """
 
-function fefmm(κ2::Array{R, N}, dx::Array{R, 1}, xs::CartesianIndex{N}) where {N, R <: AbstractFloat}
+function fefmm(κ2::Array{R, N},
+               dx::Vector{<:AbstractFloat},
+               xs::CartesianIndex{N}) where {R <: AbstractFloat, N}
     #initialization
     ordering = Array{Int}(undef, length(κ2))
     cs = cartstrides(κ2)
@@ -121,7 +123,7 @@ function fefmm(κ2::Array{R, N}, dx::Array{R, 1}, xs::CartesianIndex{N}) where {
     τ0 = ones(R, size(κ2))
     mul_analytic!(τ0, dx..., size(κ2)..., Tuple(xs)...)
     ∇τ0 = grad_analytic(τ0, dx..., size(κ2)..., Tuple(xs)...)
-    τ1 = Inf.*ones(R, size(κ2))
+    τ1 = R(Inf).*ones(R, size(κ2))
     τ1[xs] = sqrt(κ2[xs])
     tags = ones(UInt8,size(κ2))
     tags[xs] = 0x2

--- a/src/fefmm_neighbour_checks.jl
+++ b/src/fefmm_neighbour_checks.jl
@@ -63,3 +63,4 @@ end
         return false
     end 
 end
+

--- a/src/fefmm_neighbour_checks.jl
+++ b/src/fefmm_neighbour_checks.jl
@@ -16,7 +16,7 @@ function cartstrides(A::AbstractArray)
     [inds...]
 end
 
-function set_neighbours!(xn::Array{S,1}, x::S, tags::Array{UInt8, N}, cs::Array{S,1}, I1::S, Iend::S) where {N, S <: CartesianIndex{N}}
+function set_neighbours!(xn::Vector{S}, x::S, tags::Array{UInt8, N}, cs::Vector{S}, I1::S, Iend::S) where {N, S <: CartesianIndex{N}}
     for (i,s) in enumerate(cs)
         if cilt(I1, x-s) && @inbounds tags[x-s] < 0x3 
             @inbounds xn[2*i-1] = x-s

--- a/src/fefmm_nodes.jl
+++ b/src/fefmm_nodes.jl
@@ -4,3 +4,4 @@ struct Node{R <: AbstractFloat, N}
 end
 
 <(a::Node, b::Node) = a.val < b.val
+

--- a/src/fefmm_piecewise_quadratic.jl
+++ b/src/fefmm_piecewise_quadratic.jl
@@ -68,3 +68,4 @@ function solve_piecewise_quadratic(α1::R, α2::R, α3::R, β1::R, β2::R, β3::
     end
     τ1t 
 end
+

--- a/src/fefmm_utilities.jl
+++ b/src/fefmm_utilities.jl
@@ -1,10 +1,16 @@
-function mul_analytic!(τ::Array{R,1}, dx1::R, ie1::Int, xs1::Int) where {R <: AbstractFloat}
+function mul_analytic!(τ::Vector{<:AbstractFloat},
+                       dx1::AbstractFloat,
+                       ie1::Integer,
+                       xs1::Integer)
     for i1 = 1:ie1
         @inbounds τ[i1] *= sqrt(sum(((i1-xs1)*dx1)^2))
     end
 end
 
-function mul_analytic!(τ::Array{R,2}, dx1::R, dx2::R, ie1::Int, ie2::Int, xs1::Int, xs2::Int) where {R <: AbstractFloat}
+function mul_analytic!(τ::Matrix{<:AbstractFloat},
+                       dx1::AbstractFloat, dx2::AbstractFloat,
+                       ie1::Integer, ie2::Integer,
+                       xs1::Integer, xs2::Integer)
     for i2 = 1:ie2
         for i1 = 1:ie1
             @inbounds τ[i1,i2] *= sqrt(sum(((i1-xs1)*dx1)^2+((i2-xs2)*dx2)^2))
@@ -12,7 +18,10 @@ function mul_analytic!(τ::Array{R,2}, dx1::R, dx2::R, ie1::Int, ie2::Int, xs1::
     end
 end
 
-function mul_analytic!(τ::Array{R,3}, dx1::R, dx2::R, dx3::R, ie1::Int, ie2::Int, ie3::Int, xs1::Int, xs2::Int, xs3::Int) where {R <: AbstractFloat}
+function mul_analytic!(τ::Array{<:AbstractFloat,3},
+                       dx1::AbstractFloat, dx2::AbstractFloat, dx3::AbstractFloat,
+                       ie1::Integer, ie2::Integer, ie3::Integer,
+                       xs1::Integer, xs2::Integer, xs3::Integer)
     for i3 = 1:ie3
         for i2 = 1:ie2
             for i1 = 1:ie1
@@ -22,31 +31,40 @@ function mul_analytic!(τ::Array{R,3}, dx1::R, dx2::R, dx3::R, ie1::Int, ie2::In
     end
 end
 
-function grad_analytic(τ0::Array{R,1}, dx1::R, ie1::Int, xs1::Int) where {R <: AbstractFloat}
-    ∇τ0 = [ones(size(τ0))]
+function grad_analytic(τ0::Vector{R},
+                       dx1::AbstractFloat,
+                       ie1::Integer,
+                       xs1::Integer) where {R <: AbstractFloat}
+    ∇τ0 = [ones(R, size(τ0))]
     for i1 = 1:ie1
         @inbounds ∇τ0[1][i1] = dx1*(i1-xs1)/τ0[i1]
     end
     #set terms at source
-    ∇τ0[1][xs1] = one(R)
+    ∇τ0[1][xs1] = 1
     ∇τ0
 end
 
-function grad_analytic(τ0::Array{R,2}, dx1::R, dx2::R, ie1::Int, ie2::Int, xs1::Int, xs2::Int) where {R <: AbstractFloat}
-    ∇τ0 = [ones(size(τ0)), ones(size(τ0))]
+function grad_analytic(τ0::Matrix{R},
+                       dx1::AbstractFloat, dx2::AbstractFloat,
+                       ie1::Integer, ie2::Integer,
+                       xs1::Integer, xs2::Integer) where {R <: AbstractFloat}
+    ∇τ0 = [ones(R, size(τ0)), ones(R, size(τ0))]
     for i2 = 1:ie2
         for i1 = 1:ie1
             @inbounds ∇τ0[1][i1,i2] = dx1*(i1-xs1)/τ0[i1,i2]
             @inbounds ∇τ0[2][i1,i2] = dx2*(i2-xs2)/τ0[i1,i2]
         end
     end
-    ∇τ0[1][xs1, xs2] = convert(R, 1/sqrt(2))
-    ∇τ0[2][xs1, xs2] = convert(R, 1/sqrt(2))
+    ∇τ0[1][xs1, xs2] = 1/sqrt(2)
+    ∇τ0[2][xs1, xs2] = 1/sqrt(2)
     ∇τ0
 end
 
-function grad_analytic(τ0::Array{R,3}, dx1::R, dx2::R, dx3::R, ie1::Int, ie2::Int, ie3::Int, xs1::Int, xs2::Int, xs3::Int) where {R <: AbstractFloat}
-    ∇τ0 = [ones(size(τ0)), ones(size(τ0)), ones(size(τ0))]
+function grad_analytic(τ0::Array{R,3},
+                       dx1::AbstractFloat, dx2::AbstractFloat, dx3::AbstractFloat,
+                       ie1::Integer, ie2::Integer, ie3::Integer,
+                       xs1::Integer, xs2::Integer, xs3::Integer) where {R <: AbstractFloat}
+    ∇τ0 = [ones(R, size(τ0)), ones(R, size(τ0)), ones(R, size(τ0))]
     for i3 = 1:ie3
         for i2 = 1:ie2
             for i1 = 1:ie1
@@ -56,8 +74,9 @@ function grad_analytic(τ0::Array{R,3}, dx1::R, dx2::R, dx3::R, ie1::Int, ie2::I
             end
         end
     end
-    ∇τ0[1][xs1, xs2, xs3] = convert(R, 1/sqrt(3))
-    ∇τ0[2][xs1, xs2, xs3] = convert(R, 1/sqrt(3)) 
-    ∇τ0[3][xs1, xs2, xs3] = convert(R, 1/sqrt(3))       
+    ∇τ0[1][xs1, xs2, xs3] = 1/sqrt(3)
+    ∇τ0[2][xs1, xs2, xs3] = 1/sqrt(3)
+    ∇τ0[3][xs1, xs2, xs3] = 1/sqrt(3)
     ∇τ0
 end
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,6 +31,7 @@ module FEFMM_Tests
             τaxis = 0:0.1:10
             τa2d = sqrt.(τaxis'.^2 .+ τaxis.^2)
             @test all(isapprox.(τa2d, FEFMM.fefmm(κ22d, dx2d, xs2d)[1]))
+            @test all(isapprox.(Float32.(τa2d), Float32.(FEFMM.fefmm(κ22d, Float32.(dx2d), xs2d)[1])))
             κ23d = ones(101,101,101)
             dx3d = [0.1,0.1,0.1]
             xs3d = CartesianIndex(1,1,1)
@@ -43,6 +44,7 @@ module FEFMM_Tests
                 end
             end
             @test all(isapprox.(τa3d, FEFMM.fefmm(κ23d, dx3d, xs3d)[1]))
+            @test all(isapprox.(Float32.(τa3d), Float32.(FEFMM.fefmm(κ23d, Float32.(dx3d), xs3d)[1])))
         end
 
         @testset "Constant Gradient of Squared Slowness 2D" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -217,3 +217,4 @@ module FEFMM_Tests
 
     end
 end
+

--- a/test/testmediums.jl
+++ b/test/testmediums.jl
@@ -186,3 +186,4 @@ function gaussian_factor_3D(h)
     k2 = @. t_dx1*t_dx1+t_dx2*t_dx2+t_dx3*t_dx3
     (x0, k2, t1_exact.*t0)
 end
+


### PR DESCRIPTION
I came across an issue where no method is defined if the type of the grid spacings `dx` is different than that of the slowness `κ2`. This can be easily seen by changing `dx = [1.0, 1.0]` to `dx = [1.0f0, 1.0f0]` in the README.md example.

I submit this pull request to fix that. The main change is in the `fefmm` function which now takes a `dx` argument whose eltype is independent as that of `κ2`. All auxiliary arrays as well as travel-time output retains the type of `κ2`. To allow this I had to change some other auxiliary functions such as `mul_analytic!` and `grad_analytic` among others.

Some other minor changes are:

* `Inf` becomes `R(Inf)` in `fefmm`, as `Inf` is strictly `Float64`.
* `ones(size(τ0))` becomes `ones(R, size(τ0))` in `grad_analytic` to respect type
* `Int` becomes `Integer`, as `Integer` is an abstract type
* `Array{R, 1}` becomes `Vector{R}` to be more idiomatic
* `Array{R, 2}` becomes `Matrix{R}` to be more idiomatic
* Added a couple of tests
* Newlines at the end of all files